### PR TITLE
Image refresh Q1 2025

### DIFF
--- a/files/etc/sysctl.conf
+++ b/files/etc/sysctl.conf
@@ -1,0 +1,2 @@
+fs.file-max = 1048576
+vm.max_map_count = 1048576

--- a/files/etc/systemd/system/questdb.service
+++ b/files/etc/systemd/system/questdb.service
@@ -9,6 +9,8 @@ Group=questdb
 Type=simple
 Restart=always
 RestartSec=2
+Environment=QDB_PACKAGE=digitalocean-market
+LimitNOFILE=134217728
 ExecStart=/usr/bin/java \
     --add-exports java.base/jdk.internal.math=io.questdb \
     -p /usr/local/bin/questdb.jar \

--- a/scripts/01-setup.sh
+++ b/scripts/01-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# sleep timer to wait until the machine completely boots
-sleep 30
+echo "sleeping for 1 minute to wait until machine completely boots"
+sleep 60
 
 # Create questdb user
 useradd -r -d /home/questdb -s /bin/false questdb

--- a/template.pkr.hcl
+++ b/template.pkr.hcl
@@ -12,7 +12,6 @@ variable "image_id" {
 
 variable "questdb_version" {
   type        = string
-  default     = "latest"
   description = "Version number of the desired QuestDB binary."
 }
 


### PR DESCRIPTION
1. Adds sysctl parameters
2. Makes version a required packer parameter
3. Waits a bit longer for the instance to start up because the OS keeps a lock on some apt file